### PR TITLE
Update simulation script and true tract detection to the latest state of software dependencies of slendr

### DIFF
--- a/rules/00.gen_simuls_step1.smk
+++ b/rules/00.gen_simuls_step1.smk
@@ -4,7 +4,7 @@
 import numpy as np
 import pandas as pd
 
-SEED= config['model']['seed'] 
+SEED= config['model']['seed']
 MODEL = config['model']
 TIMES= config['model']['times']
 
@@ -18,7 +18,8 @@ rule slim:
     output:
         vcf="{model}_{seed}_{time}ky/results/output.vcf.gz",
         trees="{model}_{seed}_{time}ky/results/{model}_{seed}_{time}ky_output_ts.trees",
-        node="{model}_{seed}_{time}ky/results/nodes.tsv"
+        node="{model}_{seed}_{time}ky/results/nodes.tsv",
+        tracts="{model}_{seed}_{time}ky/results/{model}_{seed}_{time}ky_tracts.tsv.gz"
     conda: config['envs']
     params:
         genome = config['model']['genome_length'],
@@ -31,22 +32,6 @@ rule slim:
         "--time {wildcards.time}e3 "
         "--model {wildcards.model}_{wildcards.seed}_{wildcards.time}ky "
         "--seed {wildcards.seed} 2> {log}"
-
-rule track:
-    input:
-        vcf="{model}_{seed}_{time}ky/results/output.vcf.gz",
-        trees="{model}_{seed}_{time}ky/results/{model}_{seed}_{time}ky_output_ts.trees",
-        node="{model}_{seed}_{time}ky/results/nodes.tsv"
-    output:
-        "{model}_{seed}_{time}ky/results/{model}_{seed}_{time}ky_tracts.tsv.gz"
-    log: '{model}_{seed}_{time}ky/logs/trees_track.log'
-    params:
-        model="{model}_{seed}_{time}ky/model/",
-    shell:
-        "python scripts/00.detect_tracts.py "
-        "--slendr {params.model} "
-        "--trees  {input.trees} "
-        "--output {output} 2> {log}"
 
 rule f4_ratio:
     input:

--- a/scripts/00.introgression.R
+++ b/scripts/00.introgression.R
@@ -31,7 +31,7 @@ if (is.null(opt$ne)){
 }
 
 mod <- opt$model
-ne_pop1 <- opt$ne
+ne_pop1 <- as.integer(opt$ne)
 seglen <- as.numeric(opt$length)
 SEED <- opt$seed
 split_time <-  as.numeric(opt$time)
@@ -77,10 +77,10 @@ pops <- list(ancestor, archaic, neaA, nea2, nea1A, nea1, intN, AMH, OOA, Eurasia
 model <- compile_model(
   populations = pops, gene_flow = gf,
   generation_time = 29,
-  path = model_dir, overwrite = TRUE
+  path = model_dir, overwrite = TRUE, force = TRUE
 )
 
-plot_model(model)
+# plot_model(model)
 
 # ---------------- sampling ----------------
 nea_samples <- schedule_sampling(model, times = c(70000,40000), list(nea1, 1),list(nea2, 1))
@@ -91,7 +91,7 @@ emh_samples <- schedule_sampling(model, times = seq(split_time, 2000, by = -500)
 samples <- rbind(nea_samples, present_samples, emh_samples)
 
 
-# ---------------- slim ----------------
+# ---------------- msprime ----------------
 start_time <- Sys.time()
 ts <- msprime(
   model, sequence_length = seglen, recombination_rate = 1e-8,
@@ -99,7 +99,7 @@ ts <- msprime(
   verbose = TRUE, random_seed = SEED
 ) %>% ts_mutate(1e-8)
 
-ts_save(ts, file = file.path(output_dir, paste(mod, "_output", sep="")))
+ts_save(ts, file = file.path(output_dir, paste(mod, "_output_ts.trees", sep="")))
 
 end_time <- Sys.time()
 end_time - start_time
@@ -129,5 +129,6 @@ node_table <-
 write_tsv(node_table, file.path(output_dir,"nodes.tsv"))
 
 
-
-
+# extract the Neanderthal tract coordinates
+tracts <- ts_tracts(ts, census = 55000, source = "intN")
+write_tsv(tracts, file.path(output_dir, paste(mod, "_tracts.tsv.gz", sep="")))

--- a/scripts/00.introgression.R
+++ b/scripts/00.introgression.R
@@ -1,5 +1,5 @@
 # Run from /projects/racimolab/people/gsd818/arcIntro/introgression-sims
-# Rscript introgression.R -n 5000 -m modelA --time 
+# Rscript introgression.R -n 5000 -m modelA --time
 # Simulating Neanderthal introgression data using *slendr*
 # devtools::install_github("bodkan/slendr")
 quiet <- function(x) { suppressMessages(suppressWarnings(x)) }
@@ -12,7 +12,7 @@ quiet(library(readr))
 quiet(library(optparse))
 
 
-reticulate::use_condaenv("slendr", required = TRUE)
+init_env()
 
 option_list = list(
     make_option(c("-n", "--ne"), type="character", default=5000, help="Ne pop1"),
@@ -52,49 +52,55 @@ if (!dir.exists(output_dir)) dir.create(output_dir)
 
 # Time difference of 1.070544 hours - 10k
 # ---------------- populations ----------------
-archaic <- population("archaic", time=550e3, N=3000)
+ancestor <- population("ancestor", time = 600e3, N = 10000, remove = 549e3)
+archaic <- population("archaic", time=550e3, N=3000, parent = ancestor)
 neaA <- population("neaA", time = 350e3, N = 1000, parent =archaic)
-nea2  <- population("nea2",N=1000,time=130e3,parent=neaA, remove=35)
+nea2  <- population("nea2",N=1000,time=130e3,parent=neaA, remove=35e3)
 nea1A <- population("nea1A",N=1000, time=130e3, parent=neaA)
-nea1 <- population("nea1", N= 1000, time=90e3,parent= nea1A,remove=35)
-intN <- population("intN", N=1000, time=90e3,parent= nea1A,remove=35)
-AMH <- population("AMH",N=10000,time=550e3)
+nea1 <- population("nea1", N= 1000, time=90e3,parent= nea1A,remove=35e3)
+intN <- population("intN", N=1000, time=90e3,parent= nea1A,remove=35e3)
+AMH <- population("AMH",N=10000,time=550e3, parent = ancestor)
 OOA <- population("OOA",N=2200, time=65e3,parent=AMH)
 Eurasia <- population("Eurasia",N=5000,time=56e3,parent=OOA)
-pop1 <- population("pop1",N=ne_pop1,time=split_time,parent=Eurasia) # testing 5k and 10k 
+pop1 <- population("pop1",N=ne_pop1,time=split_time,parent=Eurasia) # testing 5k and 10k
 pop2 <- population("pop2",N=5000,time=split_time,parent=Eurasia)
 AFR <- population("AFR",N=10000,time=65e3, parent=AMH)
 
 #1.75
 # ---------------- gene flow arc to eurasia ----------------
 prop1 <- 0.0225
-gf <- geneflow(from = intN, to = Eurasia, rate = prop1, start = 55000, end = 50000)
+gf <- gene_flow(from = intN, to = Eurasia, rate = prop1, start = 55000, end = 50000)
 
-pops <- list(archaic, neaA, nea2, nea1A, nea1, intN, AMH, OOA, Eurasia, pop1, pop2, AFR)
+pops <- list(ancestor, archaic, neaA, nea2, nea1A, nea1, intN, AMH, OOA, Eurasia, pop1, pop2, AFR)
 
 # ---------------- compile model ----------------
-model <- compile(
-  populations = pops, geneflow = gf,
+model <- compile_model(
+  populations = pops, gene_flow = gf,
   generation_time = 29,
-  dir = model_dir, overwrite = TRUE
+  path = model_dir, overwrite = TRUE
 )
 
-# ---------------- sampling ----------------
-nea_samples <- sampling(model, times = c(70000,40000), list(nea1, 1),list(nea2, 1))
+plot_model(model)
 
-present_samples <- sampling(model, times = 0, list(AFR, 300), list(pop1, 100), list(pop2, 100))
-emh_samples <- sampling(model, times = seq(split_time, 2000, by = -500), list(pop1, 2), list(pop2, 2))
+# ---------------- sampling ----------------
+nea_samples <- schedule_sampling(model, times = c(70000,40000), list(nea1, 1),list(nea2, 1))
+
+present_samples <- schedule_sampling(model, times = 0, list(AFR, 300), list(pop1, 100), list(pop2, 100))
+emh_samples <- schedule_sampling(model, times = seq(split_time, 2000, by = -500), list(pop1, 2), list(pop2, 2))
 
 samples <- rbind(nea_samples, present_samples, emh_samples)
 
 
 # ---------------- slim ----------------
 start_time <- Sys.time()
-slim(
+ts <- msprime(
   model, sequence_length = seglen, recombination_rate = 1e-8,
-  sampling = samples, method = "batch", output = file.path(output_dir, paste(mod, "_output", sep="")),
-  verbose = TRUE, seed = SEED, slim_path="~/miniconda3/envs/arc/bin/slim"
-)
+  samples = samples,
+  verbose = TRUE, random_seed = SEED
+) %>% ts_mutate(1e-8)
+
+ts_save(ts, file = file.path(output_dir, paste(mod, "_output", sep="")))
+
 end_time <- Sys.time()
 end_time - start_time
 
@@ -104,23 +110,6 @@ end_time - start_time
 
 
 print("Creating vcf files")
-model <- read(model_dir)
-root_ids <- model$splits %>%
-    dplyr::filter(pop %in% c("archaic", "AMH")) %>%
-    .$pop_id %>%
-    { . + 1 }
-
-n_pops <- length(model$populations)
-migration_matrix <- matrix(0, nrow = n_pops, ncol = n_pops)
-migration_matrix[root_ids[1], root_ids[2]] <- 1
-migration_matrix[root_ids[2], root_ids[1]] <- 1
-
-treefile = paste(mod, "_output_ts.trees", sep="")
-ts <- ts_load(model, file = file.path(output_dir, treefile),
-              recapitate = TRUE, Ne = 10000, recombination_rate = 1e-8,
-              simplify = TRUE,
-              mutate = TRUE, mutation_rate = 1e-8, random_seed = SEED,
-              migration_matrix = migration_matrix)
 
 ts_vcf(ts, chrom="1", path = file.path(output_dir, "output.vcf.gz"))
 
@@ -131,11 +120,11 @@ eigen_data <- ts_eigenstrat(ts, prefix = prefix, outgroup = "chimp")
 print("nodes...")
 
 node_table <-
-  ts_data(ts, remembered = TRUE) %>%
+  ts_nodes(ts) %>%
+  filter(sampled) %>%
   filter(pop %in% c("pop1", "pop2")) %>%
   as_tibble() %>%
-  mutate(slim_id = map_int(node_id, ~ ts$node(as.integer(.x))$metadata["slim_id"])) %>%
-  select(name, pop, time, slim_id)
+  select(name, pop, time, node_id)
 
 write_tsv(node_table, file.path(output_dir,"nodes.tsv"))
 


### PR DESCRIPTION
Hello @albarema,

This pull request adds the minimum number of changes necessary to bring the project simulation pipeline script up to date in terms to avoid the pyslim software bug discovered months ago that completely broke recapitation (and resulting VCF files) from the SLiM simulation. (Fun fact: there was yet another pyslimk bug discovered after that in October, but not a back breaking one at least...)

Good news: In the current script, this is no longer an issue and the code is fixed and working (and faster, and easier to use for follow up users of this pipeline).

More complicated news: Unfortunately, a _lot_ has happened in tskit / pyslim tree sequence universe since the original SLiM-based slendr script was written for this project. Namely, several features that slendr relied on to do the recapitation were removed from tskit / pyslim in the time between when this project was actively worked on and the time when the pyslim bug was fixed by its authors. In other words, it wasn't possible (or, wasn't possible without weeks of additional work) to just update pyslim and check the results. The simulation script needed to be changed because tskit / pyslim removed functionality that slendr needed to do the trick with SLiM-based recapitation.

Good news: The changes needed were very easy to do and in fact require only to _remove some code_, instead of adding more code. In brief (the code diffs below show this in more detail), we now do this:

1. slendr simulations are NOT done with SLiM anymore, no recapitation is done, no trick with unrooted genealogies to detect true ancestry tract roots is needed.
2. slendr simulations are now done with msprime, which is infinitely faster for everyone.
3. Ancestry tracts are no longer extracted from the tree sequences file using our custom Python script `detect_tracts.py`. Instead, slendr has a new function `ts_tracts()` that can do the same directly on the tree sequence, and can also do it directly on an msprime tree-sequence output (again, no tricks from point 1. above are necessary). This uses the new tspop / link-ancestors algorithm but without any additional work of you / us.

To make this possible, I modified the `introgression.R` script so that it calls `ts_tracts()` at the very end, and saves the table of tracts to a file (replacing the need to call `detect_tracts.py` in an extra step). Note that the table has individual names directly, so no cross-checking SLiM numerical IDs of nodes with their respective individuals is needed (the `nodes.tsv` table is not needed anymore).

Unfortunately, I don't know Snakemake and wasn't able to run the pipeline to test things. Snakemake kept screaming at me that I'm missing pandas and what not, although my Python has pandas installed. That said, I ran `introgression.R` on the terminal, and everything works.

I modified the `gen_simuls_step1.smk` to the best of my ability to reflect this -- removed the rule to run `detect_tracts.py` which is not needed, and modified the rule `rule slim` (which should be named `rule msprime` now I guess) to keep track of the new tracts table. Again, I don't know Snakemake so additional few changes might be needed.

Of course, given that `nodes.tsv` is not needed because the new tracts table already has all the information needed, the more downstream code will probably have to be simplified a bit as well (no need to merge `nodes.tsv` with the tracts table to match individual names to node IDs anymore).

Before merging this PR with changes, you might want to take a peek at the diffs of those changes. I think you'll be happy to see that the `introgression.R` script (the most important thing) is actually simpler and shorter and before, and that no additional complexity was introduced by this.